### PR TITLE
Install latest Ansible version

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -42,4 +42,5 @@ echo "===> Adding hosts for convenience ..."
 mkdir -p /etc/ansible
 echo 'localhost' > /etc/ansible/hosts
 
+# Verify the Ansible installation
 ansible-playbook --version

--- a/install.sh
+++ b/install.sh
@@ -23,8 +23,8 @@ apk --update add sudo bash git openssl ca-certificates py3-cffi
 apk --update add --virtual build-dependencies libffi-dev openssl-dev build-base
 
 echo "===> Install Ansible ..."
-pip install ansible==2.7.8
-pip install ansible-lint==4.1.0
+pip install ansible
+pip install ansible-lint
 
 echo "===> Install Boto Libs ..."
 pip install --upgrade boto3


### PR DESCRIPTION
Part of the https://github.com/bitovi/bitops/issues/307

Previously, the plugin version was pinned in the installation script.
With this PR when packaging the plugin in the custom-built BitOps image, the latest version will be downloaded by default.