### PR TITLE
Set 'main-playbook: playbook.yaml' by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ ansible:
     force-handlers: true
     forks: 20
     inventory: beta
-    main-playbook: main-playbook.yaml
+    main-playbook: playbook.yaml
     skip-tags: ignore-this-tag
     tags: run-this-tag
     vault-id: [dev@dev-passwordfile, prod@prod-passwordfile]
@@ -81,6 +81,8 @@ Specify inventory host path or comma separated host list.
 ### main-plabook
 * **BitOps Property:** `main-playbook`
 * **Environment Variable:** `BITOPS_ANSIBLE_MAIN_SCRIPT`
+* **Required:** `"True"`
+* **Default:** `playbook.yaml`
 
 Specify which playbook to run ansible-playbook with
 
@@ -97,14 +99,6 @@ Only run plays and tasks whose tags do not match these values.
 * **Environment Variable:** `BITOPS_ANSIBLE_TAGS`
 
 Only run plays and tasks tagged with these values.
-
--------------------
-### main-script
-* **BitOps Property:** `main-script`
-* **Environment Variable:** `BITOPS_ANSIBLE_MAIN_SCRIPT`
-* **required:** `"True"`
-
-Pass the main playbook yaml filename that manages playbook orchestration. This config is a required parameter. 
 
 -------------------
 <!-- ### vault-id

--- a/bitops.schema.yaml
+++ b/bitops.schema.yaml
@@ -36,6 +36,7 @@ ansible:
           type: string
           export_env: ANSIBLE_MAIN_SCRIPT
           required: True
+          default: playbook.yaml
     options:
       type: object
       properties:


### PR DESCRIPTION
With an empty BitOps config for Ansible one might get the following error:
```
ERROR Configuration value: [main-playbook] is required. Please ensure you set this configuration value in the plugins `bitops.config.yaml`
```

The proposal is to set the `main-playbook: playbook.yaml` by default:
- it's consistent with BitOps v1
- already used by the [opsrepo-generator](https://github.com/bitovi/bitops-operations-repo-generator/blob/master/generators/app/templates/ansible/playbook.yaml)
- is expected ansible playbook filename
- allows empty Ansible plugin config
  - same as Terraform plugin config
  - it's easier to get started

Update: Docs PR https://github.com/bitovi/bitops/pull/372