### PR TITLE
Implementing `ANSIBLE_DRY_RUN`

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Specify Ansible vault password file for decryption. -->
 * **Environment Variable:** `BITOPS_ANSIBLE_DRYRUN`
 * **default:** `false`
 
-Will run `--list-tasks` but won't actually execute playbook(s)
+Will run `--list-tasks` and adds `--check` option
 
 ### skip-deploy
 * **BitOps Property:** `skip-deploy`

--- a/scripts/ansible_install_playbooks.sh
+++ b/scripts/ansible_install_playbooks.sh
@@ -8,6 +8,11 @@ echo "Running ansible_install_playbook.sh for $PLUGIN_DIR with args $ANSIBLE_ARG
 
 PLAYBOOK="$PLUGIN_DIR/$BITOPS_ANSIBLE_MAIN_SCRIPT"
 
+if [[ -n $BITOPS_ANSIBLE_DRYRUN ]]; then
+    # adding `--check` option to ansible args if `BITOPS_ANSIBLE_DRYRUN` is set
+    ANSIBLE_ARGS="$ANSIBLE_ARGS --check"
+fi
+
 echo "Running playbook. [ansible-playbook $PLAYBOOK $ANSIBLE_ARGS]"
 ansible-playbook $PLAYBOOK $ANSIBLE_ARGS
 

--- a/scripts/ansible_install_playbooks.sh
+++ b/scripts/ansible_install_playbooks.sh
@@ -10,7 +10,8 @@ PLAYBOOK="$PLUGIN_DIR/$BITOPS_ANSIBLE_MAIN_SCRIPT"
 
 if [[ -n $BITOPS_ANSIBLE_DRYRUN ]]; then
     # adding `--check` option to ansible args if `BITOPS_ANSIBLE_DRYRUN` is set
-    ANSIBLE_ARGS="$ANSIBLE_ARGS --check"
+    ANSIBLE_ARGS="$ANSIBLE_ARGS --check" # DRY RUN
+    ansible-playbook $PLAYBOOK "--list-tasks" # LIST TAKS
 fi
 
 echo "Running playbook. [ansible-playbook $PLAYBOOK $ANSIBLE_ARGS]"


### PR DESCRIPTION
Implements ANSIBLE_DRYRUN value to the ansible plugin. Using the `BITOPS_ANSIBLE_DRYRUN` env var will add the `--check` flag to the ansible command. 

fixes https://github.com/bitops-plugins/ansible/issues/9

# Logs
```
[Bitovi] [ansible] $ ./test.sh                  
+ PLAYBOOK=main.yaml
+ ANSIBLE_ARGS='--inventory inventory.ini'
+ [[ -n '' ]]
+ echo 'Running playbook. [ansible-playbook main.yaml --inventory inventory.ini]'
Running playbook. [ansible-playbook main.yaml --inventory inventory.ini]
[Bitovi] [ansible] $ export BITOPS_ANSIBLE_DRYRUN=true; ./test.sh 
+ PLAYBOOK=main.yaml
+ ANSIBLE_ARGS='--inventory inventory.ini'
+ [[ -n true ]]
+ ANSIBLE_ARGS='--inventory inventory.ini --check'
+ echo 'Running playbook. [ansible-playbook main.yaml --inventory inventory.ini --check]'
Running playbook. [ansible-playbook main.yaml --inventory inventory.ini --check]

```